### PR TITLE
link to repository

### DIFF
--- a/src/routes/Cargo.toml
+++ b/src/routes/Cargo.toml
@@ -4,6 +4,7 @@ description = "URI building library"
 license-file = "LICENSE"
 version = "0.1.3"
 edition = "2021"
+repository = "https://github.com/WilkinsonK/uri_routes"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
allow crates.io, rust-digger and others to link to it.